### PR TITLE
platform: Add Heltec ESP32 board

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ env:
   - PIO_ENV=openevse_featheresp32
   - PIO_ENV=openevse_esp32-gateway
   - PIO_ENV=openevse_esp32-gateway-e
+  - PIO_ENV=openevse_esp32-heltec-wifi-lora-v2
   # - SCRIPT=ci_arduino.sh
   #   BUILD_TARGET=esp8266:esp8266:huzzah:FlashSize=4M1M
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -298,3 +298,30 @@ monitor_speed = 115200
 extra_scripts = ${common.extra_scripts}
 board_build.partitions = ${common.build_partitions_esp32}
 board_build.extra_flags = "-DARDUINO_ESP32_GATEWAY=\'E\'"
+
+[env:openevse_esp32-heltec-wifi-lora-v2]
+platform = ${common.platform_esp32}
+board = heltec_wifi_lora_32_V2
+framework = arduino
+lib_deps = ${common.lib_deps}
+src_build_flags =
+  ${common.version}.dev
+  ${common.src_build_flags}
+  ${common.src_build_flags_esp32}
+  ${common.debug_flags_esp32}
+  -DWIFI_LED=25
+  -DWIFI_BUTTON=2
+  -DWIFI_LED_ON_STATE=HIGH
+  -DRAPI_PORT=Serial1
+  -DONBOARD_LEDS=0,2,4
+build_flags =
+  ${common.build_flags}
+  ${common.build_flags_esp32}
+  -DRX1=25
+  -DTX1=27
+#upload_port = openevse.local
+#upload_speed = 921600
+upload_protocol = esptool
+monitor_speed = 115200
+extra_scripts = ${common.extra_scripts}
+board_build.partitions = ${common.build_partitions_esp32}


### PR DESCRIPTION
* This board is meaningful because it is cheap, comes with a
  built-in OLED display *AND* has a built-in LoRa radio enabling
  over 6 Miles (10km) of long-range communication at a slow rate.
* Firmware boots, produces serial output, and blinks the Wifi LED
  on my local hardware.