### PR TITLE
divert_PV_ratio: adjustable requirement on available PV power before starting charge or incrementing current

### DIFF
--- a/divert_sim/RapiSender.cpp
+++ b/divert_sim/RapiSender.cpp
@@ -1,6 +1,5 @@
 #include <Arduino.h>
 #include "RapiSender.h"
-#include "debug.h"
 #include "openevse.h"
 #include "input.h"
 
@@ -9,6 +8,7 @@
 #ifdef ENABLE_DEBUG
 #define DBG
 #endif
+#define DBUGF
 
 static CommandItem commandQueueItems[RAPI_MAX_COMMANDS];
 

--- a/divert_sim/divert_sim.cpp
+++ b/divert_sim/divert_sim.cpp
@@ -7,7 +7,6 @@
 #endif
 
 #include "Console.h"
-//#include "emonesp.h"
 #include "RapiSender.h"
 #include "openevse.h"
 #include "divert.h"
@@ -46,31 +45,19 @@ time_t parse_date(const char *dateStr)
 {
   int y = 2020, M = 1, d = 1, h = 0, m = 0, s = 0;
   char ampm[5];
-  if (6 != sscanf(dateStr, "%d-%d-%dT%d:%d:%dZ", &y, &M, &d, &h, &m, &s))
-  {
-    if (6 != sscanf(dateStr, "%d-%d-%dT%d:%d:%d+00:00", &y, &M, &d, &h, &m, &s))
-    {
-      if (6 != sscanf(dateStr, "%d-%d-%d %d:%d:%d", &y, &M, &d, &h, &m, &s))
-      {
-        if (3 != sscanf(dateStr, "%d:%d %s", &h, &m, ampm))
-        {
-          if (1 == sscanf(dateStr, "%d", &s))
-          {
+  if(6 != sscanf(dateStr, "%d-%d-%dT%d:%d:%dZ", &y, &M, &d, &h, &m, &s)) {
+    if(6 != sscanf(dateStr, "%d-%d-%dT%d:%d:%d+00:00", &y, &M, &d, &h, &m, &s)) {
+      if(6 != sscanf(dateStr, "%d-%d-%d %d:%d:%d", &y, &M, &d, &h, &m, &s)) {
+        if(3 != sscanf(dateStr, "%d:%d %s", &h, &m, ampm)) {
+          if(1 == sscanf(dateStr, "%d", &s)) {
             return s;
           }
-        }
-        else
-        {
-          y = 2020;
-          M = 1;
-          d = 1;
-          s = 0;
-          if (12 == h)
-          {
+        } else {
+          y = 2020; M = 1; d = 1; s = 0;
+          if(12 == h) {
             h -= 12;
           }
-          if ('P' == ampm[0])
-          {
+          if('P' == ampm[0]) {
             h += 12;
           }
         }
@@ -92,13 +79,11 @@ time_t parse_date(const char *dateStr)
 int get_watt(const char *val)
 {
   float number = 0.0;
-  if (1 != sscanf(val, "%f", &number))
-  {
+  if(1 != sscanf(val, "%f", &number)) {
     throw std::invalid_argument("Not a number");
   }
 
-  if (kw)
-  {
+  if(kw) {
     number *= 1000;
   }
 
@@ -110,18 +95,27 @@ time_t divertmode_get_time()
   return simulated_time;
 }
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
   int voltage_arg = -1;
   std::string sep = ",";
 
   cxxopts::Options options(argv[0], " - example command line options");
   options
-      .positional_help("[optional args]")
-      .show_positional_help();
+    .positional_help("[optional args]")
+    .show_positional_help();
 
   options
-      .add_options()("help", "Print help")("d,date", "The date column", cxxopts::value<int>(date_col), "N")("s,solar", "The solar column", cxxopts::value<int>(solar_col), "N")("g,gridie", "The Grid IE column", cxxopts::value<int>(grid_ie_col), "N")("attack", "The attack factor for the smoothing", cxxopts::value<double>(divert_attack_smoothing_factor))("decay", "The decay factor for the smoothing", cxxopts::value<double>(divert_decay_smoothing_factor))("v,voltage", "The Voltage column if < 50, else the fixed voltage", cxxopts::value<int>(voltage_arg), "N")("kw", "values are KW")("sep", "Field separator", cxxopts::value<std::string>(sep));
+    .add_options()
+    ("help", "Print help")
+    ("d,date", "The date column", cxxopts::value<int>(date_col), "N")
+    ("s,solar", "The solar column", cxxopts::value<int>(solar_col), "N")
+    ("g,gridie", "The Grid IE column", cxxopts::value<int>(grid_ie_col), "N")
+    ("attack", "The attack factor for the smoothing", cxxopts::value<double>(divert_attack_smoothing_factor))
+    ("decay", "The decay factor for the smoothing", cxxopts::value<double>(divert_decay_smoothing_factor))
+    ("v,voltage", "The Voltage column if < 50, else the fixed voltage", cxxopts::value<int>(voltage_arg), "N")
+    ("kw", "values are KW")
+    ("sep", "Field separator", cxxopts::value<std::string>(sep));
 
   auto result = options.parse(argc, argv);
 
@@ -136,14 +130,10 @@ int main(int argc, char **argv)
   mqtt_solar = grid_ie_col >= 0 ? "" : "yes";
   mqtt_grid_ie = grid_ie_col >= 0 ? "yes" : "";
 
-  if (voltage_arg >= 0)
-  {
-    if (voltage_arg < 50)
-    {
+  if(voltage_arg >= 0) {
+    if(voltage_arg < 50) {
       voltage_col = voltage_arg;
-    }
-    else
-    {
+    } else {
       voltage = voltage_arg;
     }
   }
@@ -158,30 +148,23 @@ int main(int argc, char **argv)
   int row_number = 0;
 
   std::cout << "Date,Solar,Grid IE,Pilot,Charge Power,Min Charge Power,State,Smoothed Available" << std::endl;
-  for (auto &row : parser)
+  for (auto& row : parser)
   {
     try
     {
       int col = 0;
       std::string val;
 
-      for (auto &field : row)
+      for (auto& field : row)
       {
         val = field;
-        if (date_col == col)
-        {
+        if(date_col == col) {
           simulated_time = parse_date(val.c_str());
-        }
-        else if (grid_ie_col == col)
-        {
+        } else if (grid_ie_col == col) {
           grid_ie = get_watt(val.c_str());
-        }
-        else if (solar_col == col)
-        {
+        } else if (solar_col == col) {
           solar = get_watt(val.c_str());
-        }
-        else if (voltage_col == col)
-        {
+        } else if (voltage_col == col) {
           voltage = stoi(field);
         }
 
@@ -204,7 +187,7 @@ int main(int argc, char **argv)
 
       std::cout << buffer << "," << solar << "," << grid_ie << "," << ev_pilot << "," << ev_watt << "," << min_ev_watt << "," << state << "," << smoothed << std::endl;
     }
-    catch (const std::invalid_argument &e)
+    catch(const std::invalid_argument& e)
     {
     }
   }

--- a/src/app_config.cpp
+++ b/src/app_config.cpp
@@ -110,7 +110,7 @@ ConfigOpt *opts[] =
   new ConfigOptDefenition<String>(ohm, "", "ohm", "o"),
 
 // Divert settings
-  new ConfigOptDefenition<double>(divert_PV_ratio, 1.0, "divert_PV_ratio", "dpr"),
+  new ConfigOptDefenition<double>(divert_PV_ratio, 1.1, "divert_PV_ratio", "dpr"),
   new ConfigOptDefenition<double>(divert_attack_smoothing_factor, 0.4, "divert_attack_smoothing_factor", "da"),
   new ConfigOptDefenition<double>(divert_decay_smoothing_factor, 0.05, "divert_decay_smoothing_factor", "dd"),
   new ConfigOptDefenition<uint32_t>(divert_min_charge_time, (10 * 60), "divert_min_charge_time", "dt"),

--- a/src/app_config.cpp
+++ b/src/app_config.cpp
@@ -56,6 +56,7 @@ uint32_t flags;
 String ohm;
 
 // Divert settings
+double divert_PV_ratio;
 double divert_attack_smoothing_factor;
 double divert_decay_smoothing_factor;
 uint32_t divert_min_charge_time;
@@ -109,6 +110,7 @@ ConfigOpt *opts[] =
   new ConfigOptDefenition<String>(ohm, "", "ohm", "o"),
 
 // Divert settings
+  new ConfigOptDefenition<double>(divert_PV_ratio, 1.0, "divert_PV_ratio", "dpr"),
   new ConfigOptDefenition<double>(divert_attack_smoothing_factor, 0.4, "divert_attack_smoothing_factor", "da"),
   new ConfigOptDefenition<double>(divert_decay_smoothing_factor, 0.05, "divert_decay_smoothing_factor", "dd"),
   new ConfigOptDefenition<uint32_t>(divert_min_charge_time, (10 * 60), "divert_min_charge_time", "dt"),

--- a/src/app_config.h
+++ b/src/app_config.h
@@ -46,6 +46,7 @@ extern String mqtt_announce_topic;
 extern String time_zone;
 
 // Divert settings
+extern double divert_PV_ratio;
 extern double divert_attack_smoothing_factor;
 extern double divert_decay_smoothing_factor;
 extern uint32_t divert_min_charge_time;

--- a/src/divert.cpp
+++ b/src/divert.cpp
@@ -25,25 +25,25 @@
 
 // It's better to never import current from the grid but because of charging current quantification (min value of 6A and change in steps of 1A),
 // it may be better to import a fraction of the charge current and use the next charging level sooner, depending on electricity buying/selling prices.
-// The marginal fraction of current that is required to come from PV is the divert_PV_ratio. The default behavior of requiring a pure PV charge is obtained by
+// The marginal fraction of current that is required to come from PV is the divert_PV_ratio. The requiring a pure PV charge is obtained by
 // setting divert_PV_ratio to 1.0. This is the best choice when the kWh selling price is the same as the kWh night buying price.  If instead the night tarif
-// is the same as the day tarif, any available current is good to take and divert_PV_ratio optimal setting is close to 0.0.
+// is the same as the day tarif, any available current is good to take and divert_PV_ratio optimal setting is close to 0.0. Beyond 1.0, the excess of
+// divert_PV_ratio indicates the amount of power (in kW) that OpenEVSE will try to preserve. A value of 1.1 will start charging only when the
+// PV power - 100 W (reserve) reaches the minimum charging power (reproducing the legacy behavior of OpenEVSE).
 
 // If EVSE is sleeping, charging will start as soon as solar PV / excess power exceeds the divert_PV_ratio fraction of the minimum charging power.
 // Once charging begins it will not pause before a minimum amount of time has passed and this even if solar PV / excess power drops less then minimum charge rate.
 // This avoids wear on the relay and the car.
-#define GRID_IE_RESERVE_POWER (0.0)
 
 // Default to normal charging unless set. Divert mode always defaults back to 1 if unit is reset (divertmode not saved in EEPROM)
-byte divertmode = DIVERT_MODE_NORMAL;     // default normal mode
+byte divertmode = DIVERT_MODE_NORMAL; // default normal mode
 int solar = 0;
 int grid_ie = 0;
-int min_charge_current = 6;      // TO DO: set to be min charge current as set on the OpenEVSE e.g. "$GC min-current max-current"
-int max_charge_current = 32;     // TO DO: to be set to be max charge current as set on the OpenEVSE e.g. "$GC min-current max-current"
+int min_charge_current = 6;  // TO DO: set to be min charge current as set on the OpenEVSE e.g. "$GC min-current max-current"
+int max_charge_current = 32; // TO DO: to be set to be max charge current as set on the OpenEVSE e.g. "$GC min-current max-current"
 int charge_rate = 0;
 int last_state = OPENEVSE_STATE_INVALID;
 uint32_t lastUpdate = 0;
-
 
 double available_current = 0;
 double smoothed_available_current = 0;
@@ -67,42 +67,43 @@ time_t __attribute__((weak)) divertmode_get_time()
 void divertmode_update(byte newmode)
 {
   DBUGF("Set divertmode: %d", newmode);
-  if(divertmode != newmode)
+  if (divertmode != newmode)
   {
     divertmode = newmode;
 
     // restore max charge current if normal mode or zero if eco mode
-    switch(divertmode)
+    switch (divertmode)
     {
-      case DIVERT_MODE_NORMAL:
-        // Restore the max charge current
-        rapiSender.sendCmdSync(String(F("$SC ")) + String(max_charge_current));
-        DBUGF("Restore max I: %d", max_charge_current);
-        break;
+    case DIVERT_MODE_NORMAL:
+      // Restore the max charge current
+      rapiSender.sendCmdSync(String(F("$SC ")) + String(max_charge_current));
+      DBUGF("Restore max I: %d", max_charge_current);
+      break;
 
-      case DIVERT_MODE_ECO:
-        charge_rate = 0;
-        available_current = 0;
-        smoothed_available_current = 0;
-        min_charge_end = 0;
-        
-        // Read the current charge current, assume this is the max set by the user
-        if(0 == rapiSender.sendCmdSync(F("$GE"))) {
-          max_charge_current = String(rapiSender.getToken(1)).toInt();
-          DBUGF("Read max I: %d", max_charge_current);
-        }
-        if(OPENEVSE_STATE_SLEEPING != state)
+    case DIVERT_MODE_ECO:
+      charge_rate = 0;
+      available_current = 0;
+      smoothed_available_current = 0;
+      min_charge_end = 0;
+
+      // Read the current charge current, assume this is the max set by the user
+      if (0 == rapiSender.sendCmdSync(F("$GE")))
+      {
+        max_charge_current = String(rapiSender.getToken(1)).toInt();
+        DBUGF("Read max I: %d", max_charge_current);
+      }
+      if (OPENEVSE_STATE_SLEEPING != state)
+      {
+        if (0 == rapiSender.sendCmdSync(config_pause_uses_disabled() ? F("$FD") : F("$FS")))
         {
-          if(0 == rapiSender.sendCmdSync(config_pause_uses_disabled() ? F("$FD") : F("$FS"))) 
-          {
-            DBUGLN(F("Divert activated, entered sleep mode"));
-            divert_active = false;
-          }
+          DBUGLN(F("Divert activated, entered sleep mode"));
+          divert_active = false;
         }
-        break;
+      }
+      break;
 
-      default:
-        return;
+    default:
+      return;
     }
 
     StaticJsonDocument<128> event;
@@ -127,9 +128,12 @@ void divert_update_state()
   StaticJsonDocument<128> event;
   event["divert_update"] = 0;
 
-  if(mqtt_grid_ie != "") {
+  if (mqtt_grid_ie != "")
+  {
     event["grid_ie"] = grid_ie;
-  } else {
+  }
+  else
+  {
     event["solar"] = solar;
   }
 
@@ -139,7 +143,8 @@ void divert_update_state()
     int current_charge_rate = charge_rate;
 
     // Read the current charge rate
-    if(0 == rapiSender.sendCmdSync(F("$GE"))) {
+    if (0 == rapiSender.sendCmdSync(F("$GE")))
+    {
       current_charge_rate = String(rapiSender.getToken(1)).toInt();
       DBUGVAR(current_charge_rate);
     }
@@ -157,7 +162,8 @@ void divert_update_state()
       DBUGVAR(Igrid_ie);
 
       // Subtract the current charge the EV is using from the Grid IE
-      if(0 == rapiSender.sendCmdSync(F("$GG"))) {
+      if (0 == rapiSender.sendCmdSync(F("$GG")))
+      {
         int milliAmps = String(rapiSender.getToken(1)).toInt();
         double amps = (double)milliAmps / 1000.0;
         DBUGVAR(amps);
@@ -168,7 +174,7 @@ void divert_update_state()
       if (Igrid_ie < 0)
       {
         // If excess power
-        double reserve = GRID_IE_RESERVE_POWER / voltage;
+        double reserve = (1000.0 * ((divert_PV_ratio > 1.0) ? (divert_PV_ratio - 1.0) : 0.0)) / voltage;
         DBUGVAR(reserve);
         available_current = (-Igrid_ie - reserve);
       }
@@ -178,14 +184,15 @@ void divert_update_state()
         available_current = 0;
       }
     }
-    else if (mqtt_solar!="")
+    else if (mqtt_solar != "")
     {
       // if grid feed is not available: charge rate = solar generation
       DBUGVAR(voltage);
       available_current = (double)solar / voltage;
     }
 
-    if(available_current < 0) {
+    if (available_current < 0)
+    {
       available_current = 0;
     }
     DBUGVAR(available_current);
@@ -196,12 +203,13 @@ void divert_update_state()
 
     charge_rate = (int)floor(available_current);
     // if the remaining current can be used with a sufficient ratio of PV current in it, use it
-    if ((available_current - charge_rate) > divert_PV_ratio)
+    if ((available_current - charge_rate) > min(1.0, divert_PV_ratio))
     {
       charge_rate += 1;
     }
 
-    if(OPENEVSE_STATE_SLEEPING != state) {
+    if (OPENEVSE_STATE_SLEEPING != state)
+    {
       // If we are not sleeping, make sure we are the minimum current
       charge_rate = max(charge_rate, static_cast<int>(min_charge_current));
     }
@@ -209,25 +217,28 @@ void divert_update_state()
     DBUGVAR(charge_rate);
 
     // the smoothed current suffices to ensure a sufficient ratio of PV power
-    if (smoothed_available_current >= (min_charge_current * divert_PV_ratio))
+    if (smoothed_available_current >= (min_charge_current * min(1.0, divert_PV_ratio)))
     {
       // Cap the charge rate at the configured maximum
       charge_rate = min(charge_rate, static_cast<int>(max_charge_current));
 
       // Change the charge rate if needed
-      if(current_charge_rate != charge_rate)
+      if (current_charge_rate != charge_rate)
       {
         // Set charge rate via RAPI
         bool chargeRateSet = false;
         // Try and set current with new API with volatile flag (don't save the current rate to EEPROM)
-        if(0 == rapiSender.sendCmdSync(String(F("$SC ")) + String(charge_rate) + String(F(" V")))) {
+        if (0 == rapiSender.sendCmdSync(String(F("$SC ")) + String(charge_rate) + String(F(" V"))))
+        {
           chargeRateSet = true;
-        } else if(0 == rapiSender.sendCmdSync(String(F("$SC ")) + String(charge_rate))) {
+        }
+        else if (0 == rapiSender.sendCmdSync(String(F("$SC ")) + String(charge_rate)))
+        {
           // Fallback to old API
           chargeRateSet = true;
         }
 
-        if(true == chargeRateSet) 
+        if (true == chargeRateSet)
         {
           DBUGF("Charge rate set to %d", charge_rate);
           pilot = charge_rate;
@@ -241,29 +252,31 @@ void divert_update_state()
         bool chargeStarted = false;
 
         // Check if the timer is enabled, we need to do a bit of hackery if it is
-        if(0 == rapiSender.sendCmdSync("$GD"))
+        if (0 == rapiSender.sendCmdSync("$GD"))
         {
-          if(rapiSender.getTokenCnt() >= 5 &&
-             (0 != String(rapiSender.getToken(1)).toInt() ||
-              0 != String(rapiSender.getToken(2)).toInt() ||
-              0 != String(rapiSender.getToken(3)).toInt() ||
-              0 != String(rapiSender.getToken(4)).toInt()))
+          if (rapiSender.getTokenCnt() >= 5 &&
+              (0 != String(rapiSender.getToken(1)).toInt() ||
+               0 != String(rapiSender.getToken(2)).toInt() ||
+               0 != String(rapiSender.getToken(3)).toInt() ||
+               0 != String(rapiSender.getToken(4)).toInt()))
           {
             // Timer is enabled so we need to emulate a button press to work around
             // an issue with $FE not working
-            if(false == chargeStarted && 0 == rapiSender.sendCmdSync(F("$F1"))) {
+            if (false == chargeStarted && 0 == rapiSender.sendCmdSync(F("$F1")))
+            {
               DBUGLN(F("Starting charge with button press"));
               chargeStarted = true;
             }
           }
         }
 
-        if(false == chargeStarted && 0 == rapiSender.sendCmdSync(F("$FE"))) {
+        if (false == chargeStarted && 0 == rapiSender.sendCmdSync(F("$FE")))
+        {
           DBUGLN(F("Starting charge"));
           chargeStarted = true;
         }
 
-        if(chargeStarted) 
+        if (chargeStarted)
         {
           min_charge_end = divertmode_get_time() + divert_min_charge_time;
           event["divert_active"] = divert_active = true;
@@ -272,16 +285,17 @@ void divert_update_state()
     }
     else
     {
-      if(OPENEVSE_STATE_SLEEPING != state)
+      if (OPENEVSE_STATE_SLEEPING != state)
       {
-        if(divert_active && divertmode_get_time() >= min_charge_end) 
+        if (divert_active && divertmode_get_time() >= min_charge_end)
         {
-          if(0 == rapiSender.sendCmdSync(config_pause_uses_disabled() ? F("$FD") : F("$FS"))) 
+          if (0 == rapiSender.sendCmdSync(config_pause_uses_disabled() ? F("$FD") : F("$FS")))
           {
             DBUGLN(F("Charge Stopped"));
             event["divert_active"] = divert_active = false;
 
-            if(0 == rapiSender.sendCmdSync(String(F("$SC ")) + String(max_charge_current))) {
+            if (0 == rapiSender.sendCmdSync(String(F("$SC ")) + String(max_charge_current)))
+            {
               DBUGF("Restore max I: %d", max_charge_current);
             }
           }

--- a/src/divert.cpp
+++ b/src/divert.cpp
@@ -36,14 +36,15 @@
 // This avoids wear on the relay and the car.
 
 // Default to normal charging unless set. Divert mode always defaults back to 1 if unit is reset (divertmode not saved in EEPROM)
-byte divertmode = DIVERT_MODE_NORMAL; // default normal mode
+byte divertmode = DIVERT_MODE_NORMAL;     // default normal mode
 int solar = 0;
 int grid_ie = 0;
-int min_charge_current = 6;  // TO DO: set to be min charge current as set on the OpenEVSE e.g. "$GC min-current max-current"
-int max_charge_current = 32; // TO DO: to be set to be max charge current as set on the OpenEVSE e.g. "$GC min-current max-current"
+int min_charge_current = 6;      // TO DO: set to be min charge current as set on the OpenEVSE e.g. "$GC min-current max-current"
+int max_charge_current = 32;     // TO DO: to be set to be max charge current as set on the OpenEVSE e.g. "$GC min-current max-current"
 int charge_rate = 0;
 int last_state = OPENEVSE_STATE_INVALID;
 uint32_t lastUpdate = 0;
+
 
 double available_current = 0;
 double smoothed_available_current = 0;
@@ -67,43 +68,42 @@ time_t __attribute__((weak)) divertmode_get_time()
 void divertmode_update(byte newmode)
 {
   DBUGF("Set divertmode: %d", newmode);
-  if (divertmode != newmode)
+  if(divertmode != newmode)
   {
     divertmode = newmode;
 
     // restore max charge current if normal mode or zero if eco mode
-    switch (divertmode)
+    switch(divertmode)
     {
-    case DIVERT_MODE_NORMAL:
-      // Restore the max charge current
-      rapiSender.sendCmdSync(String(F("$SC ")) + String(max_charge_current));
-      DBUGF("Restore max I: %d", max_charge_current);
-      break;
+      case DIVERT_MODE_NORMAL:
+        // Restore the max charge current
+        rapiSender.sendCmdSync(String(F("$SC ")) + String(max_charge_current));
+        DBUGF("Restore max I: %d", max_charge_current);
+        break;
 
-    case DIVERT_MODE_ECO:
-      charge_rate = 0;
-      available_current = 0;
-      smoothed_available_current = 0;
-      min_charge_end = 0;
-
-      // Read the current charge current, assume this is the max set by the user
-      if (0 == rapiSender.sendCmdSync(F("$GE")))
-      {
-        max_charge_current = String(rapiSender.getToken(1)).toInt();
-        DBUGF("Read max I: %d", max_charge_current);
-      }
-      if (OPENEVSE_STATE_SLEEPING != state)
-      {
-        if (0 == rapiSender.sendCmdSync(config_pause_uses_disabled() ? F("$FD") : F("$FS")))
-        {
-          DBUGLN(F("Divert activated, entered sleep mode"));
-          divert_active = false;
+      case DIVERT_MODE_ECO:
+        charge_rate = 0;
+        available_current = 0;
+        smoothed_available_current = 0;
+        min_charge_end = 0;
+        
+        // Read the current charge current, assume this is the max set by the user
+        if(0 == rapiSender.sendCmdSync(F("$GE"))) {
+          max_charge_current = String(rapiSender.getToken(1)).toInt();
+          DBUGF("Read max I: %d", max_charge_current);
         }
-      }
-      break;
+        if(OPENEVSE_STATE_SLEEPING != state)
+        {
+          if(0 == rapiSender.sendCmdSync(config_pause_uses_disabled() ? F("$FD") : F("$FS"))) 
+          {
+            DBUGLN(F("Divert activated, entered sleep mode"));
+            divert_active = false;
+          }
+        }
+        break;
 
-    default:
-      return;
+      default:
+        return;
     }
 
     StaticJsonDocument<128> event;
@@ -128,12 +128,9 @@ void divert_update_state()
   StaticJsonDocument<128> event;
   event["divert_update"] = 0;
 
-  if (mqtt_grid_ie != "")
-  {
+  if(mqtt_grid_ie != "") {
     event["grid_ie"] = grid_ie;
-  }
-  else
-  {
+  } else {
     event["solar"] = solar;
   }
 
@@ -143,8 +140,7 @@ void divert_update_state()
     int current_charge_rate = charge_rate;
 
     // Read the current charge rate
-    if (0 == rapiSender.sendCmdSync(F("$GE")))
-    {
+    if(0 == rapiSender.sendCmdSync(F("$GE"))) {
       current_charge_rate = String(rapiSender.getToken(1)).toInt();
       DBUGVAR(current_charge_rate);
     }
@@ -162,8 +158,7 @@ void divert_update_state()
       DBUGVAR(Igrid_ie);
 
       // Subtract the current charge the EV is using from the Grid IE
-      if (0 == rapiSender.sendCmdSync(F("$GG")))
-      {
+      if(0 == rapiSender.sendCmdSync(F("$GG"))) {
         int milliAmps = String(rapiSender.getToken(1)).toInt();
         double amps = (double)milliAmps / 1000.0;
         DBUGVAR(amps);
@@ -184,15 +179,14 @@ void divert_update_state()
         available_current = 0;
       }
     }
-    else if (mqtt_solar != "")
+    else if (mqtt_solar!="")
     {
       // if grid feed is not available: charge rate = solar generation
       DBUGVAR(voltage);
       available_current = (double)solar / voltage;
     }
 
-    if (available_current < 0)
-    {
+    if(available_current < 0) {
       available_current = 0;
     }
     DBUGVAR(available_current);
@@ -208,8 +202,7 @@ void divert_update_state()
       charge_rate += 1;
     }
 
-    if (OPENEVSE_STATE_SLEEPING != state)
-    {
+    if(OPENEVSE_STATE_SLEEPING != state) {
       // If we are not sleeping, make sure we are the minimum current
       charge_rate = max(charge_rate, static_cast<int>(min_charge_current));
     }
@@ -223,22 +216,19 @@ void divert_update_state()
       charge_rate = min(charge_rate, static_cast<int>(max_charge_current));
 
       // Change the charge rate if needed
-      if (current_charge_rate != charge_rate)
+      if(current_charge_rate != charge_rate)
       {
         // Set charge rate via RAPI
         bool chargeRateSet = false;
         // Try and set current with new API with volatile flag (don't save the current rate to EEPROM)
-        if (0 == rapiSender.sendCmdSync(String(F("$SC ")) + String(charge_rate) + String(F(" V"))))
-        {
+        if(0 == rapiSender.sendCmdSync(String(F("$SC ")) + String(charge_rate) + String(F(" V")))) {
           chargeRateSet = true;
-        }
-        else if (0 == rapiSender.sendCmdSync(String(F("$SC ")) + String(charge_rate)))
-        {
+        } else if(0 == rapiSender.sendCmdSync(String(F("$SC ")) + String(charge_rate))) {
           // Fallback to old API
           chargeRateSet = true;
         }
 
-        if (true == chargeRateSet)
+        if(true == chargeRateSet) 
         {
           DBUGF("Charge rate set to %d", charge_rate);
           pilot = charge_rate;
@@ -252,31 +242,29 @@ void divert_update_state()
         bool chargeStarted = false;
 
         // Check if the timer is enabled, we need to do a bit of hackery if it is
-        if (0 == rapiSender.sendCmdSync("$GD"))
+        if(0 == rapiSender.sendCmdSync("$GD"))
         {
-          if (rapiSender.getTokenCnt() >= 5 &&
-              (0 != String(rapiSender.getToken(1)).toInt() ||
-               0 != String(rapiSender.getToken(2)).toInt() ||
-               0 != String(rapiSender.getToken(3)).toInt() ||
-               0 != String(rapiSender.getToken(4)).toInt()))
+          if(rapiSender.getTokenCnt() >= 5 &&
+             (0 != String(rapiSender.getToken(1)).toInt() ||
+              0 != String(rapiSender.getToken(2)).toInt() ||
+              0 != String(rapiSender.getToken(3)).toInt() ||
+              0 != String(rapiSender.getToken(4)).toInt()))
           {
             // Timer is enabled so we need to emulate a button press to work around
             // an issue with $FE not working
-            if (false == chargeStarted && 0 == rapiSender.sendCmdSync(F("$F1")))
-            {
+            if(false == chargeStarted && 0 == rapiSender.sendCmdSync(F("$F1"))) {
               DBUGLN(F("Starting charge with button press"));
               chargeStarted = true;
             }
           }
         }
 
-        if (false == chargeStarted && 0 == rapiSender.sendCmdSync(F("$FE")))
-        {
+        if(false == chargeStarted && 0 == rapiSender.sendCmdSync(F("$FE"))) {
           DBUGLN(F("Starting charge"));
           chargeStarted = true;
         }
 
-        if (chargeStarted)
+        if(chargeStarted) 
         {
           min_charge_end = divertmode_get_time() + divert_min_charge_time;
           event["divert_active"] = divert_active = true;
@@ -285,17 +273,16 @@ void divert_update_state()
     }
     else
     {
-      if (OPENEVSE_STATE_SLEEPING != state)
+      if(OPENEVSE_STATE_SLEEPING != state)
       {
-        if (divert_active && divertmode_get_time() >= min_charge_end)
+        if(divert_active && divertmode_get_time() >= min_charge_end) 
         {
-          if (0 == rapiSender.sendCmdSync(config_pause_uses_disabled() ? F("$FD") : F("$FS")))
+          if(0 == rapiSender.sendCmdSync(config_pause_uses_disabled() ? F("$FD") : F("$FS"))) 
           {
             DBUGLN(F("Charge Stopped"));
             event["divert_active"] = divert_active = false;
 
-            if (0 == rapiSender.sendCmdSync(String(F("$SC ")) + String(max_charge_current)))
-            {
+            if(0 == rapiSender.sendCmdSync(String(F("$SC ")) + String(max_charge_current))) {
               DBUGF("Restore max I: %d", max_charge_current);
             }
           }


### PR DESCRIPTION
    Adds a divert_PV_ratio parameter with a default value of 1.0 that 
    requires 100% of PV power for starting charging. There is a related wifi gui
    pull request. This compiles fines but has not been tested. Some feedback
    from the Open EVSE team would be welcome before I test flashing my
    ESP32.

    Motivation

    Because charge cannot start with less than 6A, and is incremented by
    steps of 1A, it is not possible for OpenEVSE to exactly consume the
    available excess of PV power. The divert_PV_ratio declares what
    minimum fraction of PV power is required to start charging or
    increment charging current.
    
    The default of 1.0 means that charging only starts (or is incremented)
    when all the required power is available as excess PV power. A higher
    value (1.1) would start only with an extra safety margin.
    
    Values below 1.0 are economically preferable if the kWh selling price
    is strictly less than the kWh night-price which is the usual
    situation. In this case, if the current fraction of excedent PV power
    is sufficient to make the extra imported power cost less than it would
    cost with the night price, it's better to charge now.
    
    As a rule of thumb, if the Daylight price is noted "D", the Night
    price "N" and the selling price "S", the optimal setting for the
    divert_PV_ratio is:
    
                      (D-N)/(D-S)
    
    If the actual (Daylight) price is 0.15/kWh but there is cheap Night
    charging price of 0.10/kWh and an actual selling price of 0.05/kWh
    then the best ratio to use is:
    
        (0.15 - 0.10)/(0.15 - 0.05) = 0.05/0.1 = 0.5