### PR TITLE
Fix CORS for zones.js and timeout using espota for upload

### DIFF
--- a/src/ota.cpp
+++ b/src/ota.cpp
@@ -2,7 +2,7 @@
 #include "ota.h"
 
 #include <WiFiUdp.h>
-#include <ArduinoOTA.h>               // local OTA update from Arduino IDE
+#include <ArduinoOTA.h> // local OTA update from Arduino IDE
 #include <FS.h>
 
 #include "lcd.h"
@@ -27,11 +27,13 @@ void ota_setup()
 
   ArduinoOTA.onProgress([](unsigned int progress, unsigned int total) {
     int percent = progress / (total / 100);
-    if(percent != lastPercent) {
+    if (percent != lastPercent)
+    {
       DBUGF("ArduinoOTA progress %d%%", percent);
       String text = String(percent) + F("%");
       lcd_display(text, 0, 1, 10 * 1000, LCD_DISPLAY_NOW);
       lastPercent = percent;
+      feedLoopWDT();
     }
   });
 

--- a/src/web_server_static.cpp
+++ b/src/web_server_static.cpp
@@ -10,6 +10,8 @@
 #include "app_config.h"
 #include "net_manager.h"
 
+extern bool enableCors; // defined in web_server.cpp
+
 // Static files
 struct StaticFile
 {
@@ -84,6 +86,12 @@ bool web_static_handle(MongooseHttpServerRequest *request)
     response->setCode(200);
     response->setContentType(file->type);
     response->setContentLength(file->length);
+
+    if (enableCors)
+    {
+      response->addHeader(F("Access-Control-Allow-Origin"), F("*"));
+    }
+
     response->setContent((const uint8_t *)file->data, file->length);
 
     request->send(response);


### PR DESCRIPTION
Two minor fixes:
- Fix CORS for zones.js, by adding "Access-Control-Allow-Origin" header to all static requests
- timeout using espota for upload, by add feedLoopWDT in onProgress