### PR TITLE
Remove the legacy API and ENABLE_LEGACY_API flag

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,7 +17,6 @@
 ; - ENABLE_DEBUG_RAPI - Enable debug of the RAPI code (noisy)
 ; - ENABLE_PROFILE - Turn on the profiling
 ; - ENABLE_OTA - Enable Arduino OTA update
-; - ENABLE_LEGACY_API - Enable APIs from older versions of the WiFi firmware
 ; - ENABLE_ASYNC_WIFI_SCAN - Enable use of the async WiFI scanning, requires Git version of ESP core
 ;
 ; Config

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -32,22 +32,12 @@ bool temp3_valid = false;
 long pilot = 0;                       // OpenEVSE Pilot Setting
 long state = OPENEVSE_STATE_STARTING; // OpenEVSE State
 long elapsed = 0;                     // Elapsed time (only valid if charging)
-#ifdef ENABLE_LEGACY_API
-String estate = "Unknown"; // Common name for State
-#endif
 
 // Defaults OpenEVSE Settings
 byte rgb_lcd = 1;
 byte serial_dbg = 0;
 byte auto_service = 1;
 int service = 1;
-
-#ifdef ENABLE_LEGACY_API
-long current_l1min = 0;
-long current_l2min = 0;
-long current_l1max = 0;
-long current_l2max = 0;
-#endif
 
 long current_scale = 0;
 long current_offset = 0;
@@ -67,12 +57,6 @@ String protocol = "-";
 long gfci_count = 0;
 long nognd_count = 0;
 long stuck_count = 0;
-
-// OpenEVSE Session options
-#ifdef ENABLE_LEGACY_API
-long kwh_limit = 0;
-long time_limit = 0;
-#endif
 
 // OpenEVSE Usage Statistics
 long wattsec = 0;
@@ -247,34 +231,6 @@ handleRapiRead()
     }
   });
 
-#ifdef ENABLE_LEGACY_API
-  rapiSender.sendCmd("$GH", [](int ret)
-  {
-    if(RAPI_RESPONSE_OK == ret)
-    {
-      if(rapiSender.getTokenCnt() >= 2)
-      {
-        const char *val;
-        val = rapiSender.getToken(1);
-        kwh_limit = strtol(val, NULL, 10);
-      }
-    }
-  });
-
-  rapiSender.sendCmd("$G3", [](int ret)
-  {
-    if(RAPI_RESPONSE_OK == ret)
-    {
-      if(rapiSender.getTokenCnt() >= 2)
-      {
-        const char *val;
-        val = rapiSender.getToken(1);
-        time_limit = strtol(val, NULL, 10);
-      }
-    }
-  });
-#endif
-
   rapiSender.sendCmd("$GE", [](int ret)
   {
     if(RAPI_RESPONSE_OK == ret)
@@ -300,30 +256,6 @@ handleRapiRead()
       temp_ck = bitRead(flags, 10);
     }
   });
-
-#ifdef ENABLE_LEGACY_API
-  rapiSender.sendCmd("$GC", [](int ret)
-  {
-    if(RAPI_RESPONSE_OK == ret)
-    {
-      if(rapiSender.getTokenCnt() >= 3)
-      {
-        const char *val;
-        if (service == 1) {
-          val = rapiSender.getToken(1);
-          current_l1min = strtol(val, NULL, 10);
-          val = rapiSender.getToken(2);
-          current_l1max = strtol(val, NULL, 10);
-        } else {
-          val = rapiSender.getToken(1);
-          current_l2min = strtol(val, NULL, 10);
-          val = rapiSender.getToken(2);
-          current_l2max = strtol(val, NULL, 10);
-        }
-      }
-    }
-  });
-#endif
 
   Profile_End(handleRapiRead, 10);
 }

--- a/src/input.h
+++ b/src/input.h
@@ -21,20 +21,12 @@ extern bool temp3_valid;
 extern long pilot;  // OpenEVSE Pilot Setting
 extern long state;    // OpenEVSE State
 extern long elapsed;  // Elapsed time (only valid if charging)
-extern String estate; // Common name for State
 
 //Defaults OpenEVSE Settings
 extern byte rgb_lcd;
 extern byte serial_dbg;
 extern byte auto_service;
 extern int service;
-
-#ifdef ENABLE_LEGACY_API
-extern long current_l1min;
-extern long current_l2min;
-extern long current_l1max;
-extern long current_l2max;
-#endif
 
 extern long current_scale;
 extern long current_offset;
@@ -55,12 +47,6 @@ extern String protocol;
 extern long gfci_count;
 extern long nognd_count;
 extern long stuck_count;
-
-//OpenEVSE Session
-#ifdef ENABLE_LEGACY_API
-extern long kwh_limit;
-extern long time_limit;
-#endif
 
 //OpenEVSE Usage Statistics
 extern long wattsec;

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -712,44 +712,6 @@ handleConfig(MongooseHttpServerRequest *request)
   request->send(response);
 }
 
-#ifdef ENABLE_LEGACY_API
-// -------------------------------------------------------------------
-// Returns Updates JSON
-// url: /rapiupdate
-// -------------------------------------------------------------------
-void
-handleUpdate(MongooseHttpServerRequest *request) {
-
-  MongooseHttpServerResponseStream *response;
-  if(false == requestPreProcess(request, response)) {
-    return;
-  }
-
-  String s = "{";
-  s += "\"comm_sent\":" + String(rapiSender.getSent()) + ",";
-  s += "\"comm_success\":" + String(rapiSender.getSuccess()) + ",";
-  s += "\"ohmhour\":\"" + ohm_hour + "\",";
-  s += "\"espfree\":\"" + String(espfree) + "\",";
-  s += "\"packets_sent\":\"" + String(packets_sent) + "\",";
-  s += "\"packets_success\":\"" + String(packets_success) + "\",";
-  s += "\"amp\":" + amp + ",";
-  s += "\"pilot\":" + pilot + ",";
-  s += "\"temp1\":" + temp1 + ",";
-  s += "\"temp2\":" + temp2 + ",";
-  s += "\"temp3\":" + temp3 + ",";
-  s += "\"state\":" + String(state) + ",";
-  s += "\"elapsed\":" + String(elapsed) + ",";
-  s += "\"estate\":\"" + estate + "\",";
-  s += "\"wattsec\":" + wattsec + ",";
-  s += "\"watthour\":" + watthour_total;
-  s += "}";
-
-  response->setCode(200);
-  response->print(s);
-  request->send(response);
-}
-#endif
-
 // -------------------------------------------------------------------
 // Reset config and reboot
 // url: /reset


### PR DESCRIPTION
This flag was first introduced in 2017, and now that we've moved from
ESP8266 to ESP32, this feels like a good time to get rid of this code.
It is not enabled by default in any build configuration, and a lot of it
was gutted in an earlier commit 48cc8e064.

This endpoint has been merged with the status endpoint since 2017 in
commit 54987e6bdaa.

@jeremypoulter, I would definitely appreciate your input here on whether this is a good idea, and if not, why this should stick around as I'm not sure what would still be expecting to use this.