### PR TITLE
CORS fix for /config

### DIFF
--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -136,6 +136,8 @@ bool requestPreProcess(MongooseHttpServerRequest *request, MongooseHttpServerRes
 
   if(enableCors) {
     response->addHeader(F("Access-Control-Allow-Origin"), F("*"));
+    response->addHeader(F("Access-Control-Allow-Headers"), F("*"));
+    response->addHeader(F("Access-Control-Allow-Methods"), F("*"));
   }
 
   response->addHeader(F("Cache-Control"), F("no-cache, private, no-store, must-revalidate, max-stale=0, post-check=0, pre-check=0"));
@@ -685,6 +687,8 @@ handleConfig(MongooseHttpServerRequest *request)
     handleConfigGet(request, response);
   } else if(HTTP_POST == request->method()) {
     handleConfigPost(request, response); 
+  } else if(HTTP_OPTIONS == request->method()) {
+    response->setCode(200);
   } else {
     response->setCode(405);
 


### PR DESCRIPTION
Using via openevse.local gave CORS errors when posting to /config. (Due to preflight OPTIONS request not being handled properly: [Mozilla Documentation](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request#:~:text=A%20CORS%20preflight%20request%20is,Headers%20%2C%20and%20the%20Origin%20header).)