### PR TITLE
Don't allow voltage to be set outside of 60-300 volts via MQTT

### DIFF
--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -57,11 +57,16 @@ void mqttmsg_callback(MongooseString topic, MongooseString payload) {
     divert_update_state();
   }
   else if (topic_string == mqtt_vrms){
-    voltage = payload_str.toFloat();
-    DBUGF("voltage:%.1f", voltage);
-    OpenEVSE.setVoltage(voltage, [](int ret) {
-      // Only gives better power calculations so not critical if this fails
-    });
+    double volts = payload_str.toFloat();
+    if (volts > 0.0) {
+      voltage = volts;
+      DBUGF("voltage:%.1f", voltage);
+      OpenEVSE.setVoltage(voltage, [](int ret) {
+        // Only gives better power calculations so not critical if this fails
+      });
+    } else {
+      DBUGLN("Ignoring voltage (was <= 0.0)")
+    }
   }
   // If MQTT message to set divert mode is received
   else if (topic_string == mqtt_topic + "/divertmode/set"){

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -58,14 +58,14 @@ void mqttmsg_callback(MongooseString topic, MongooseString payload) {
   }
   else if (topic_string == mqtt_vrms){
     double volts = payload_str.toFloat();
-    if (volts > 0.0) {
+    if (volts >= 60.0 && volts <= 300.0) {
       voltage = volts;
-      DBUGF("voltage:%.1f", voltage);
-      OpenEVSE.setVoltage(voltage, [](int ret) {
+      DBUGF("voltage:%.1f", volts);
+      OpenEVSE.setVoltage(volts, [](int ret) {
         // Only gives better power calculations so not critical if this fails
       });
     } else {
-      DBUGLN("Ignoring voltage (was <= 0.0)")
+      DBUGF("voltage:%.1f (ignoring, out of range)", volts);
     }
   }
   // If MQTT message to set divert mode is received


### PR DESCRIPTION
Voltage is used by divert mode, as well as sent along to the OpenEVSE
module for power calculations.

Setting this to zero could result in a lot of issues. The divert code
would see divide by zero happen, and the energy montoring code on the
OpenEVSE module would result in the recorded energy usage being
incorrect.

While this shouldn't happen reguarly, I found myself in this situation
by sending a null/zero-length message to the relevant topic that the
ESP32 was listening on. Because there is no error checking in the float
parsing code, a null value parsed to zero, which resulted in the voltage
value being set to zero.

An alternative here would be to reset the voltage to `DEFAULT_VOLTAGE`
if a zero or invalid value was received. As written, this will simply do
nothing and ignore the invalid/zero value. Thoughts here? Happy to
change this PR; straightforward to add one line to the else case:
`voltage = DEFAULT_VOLTAGE;`

Example after running `mosquitto_pub -n -t my/topic/vrms`:

<img width="443" alt="zero-voltage" src="https://user-images.githubusercontent.com/265817/101302932-80631800-3802-11eb-8785-06f1869a56ce.png">

There might be additional validation/verification wanted around the solar and grid I/E feeds as well. However, this is a bit trickier, as zero and negative values are possible, so we'd likely want to move away from `toInt` and use `strtol` or something directly to be able to detect error cases. Alternatively, we can just ensure the value to be processed is not the empty string. Should I attempt to catch and handle these cases as well?